### PR TITLE
copy to both icls and xml formats

### DIFF
--- a/buildjar.bat
+++ b/buildjar.bat
@@ -1,6 +1,8 @@
 mkdir .\colors
 copy "Solarized Light.xml" .\colors
 copy "Solarized Dark.xml" .\colors
+copy "Solarized Light.xml" ".\colors\Solarized Light.icls"
+copy "Solarized Dark.xml" ".\colors\Solarized Dark.icls"
 copy /y nul .\"IntelliJ IDEA Global Settings"
 
 jar cfM settings.jar "IntelliJ IDEA Global Settings" .\colors

--- a/buildjar.sh
+++ b/buildjar.sh
@@ -3,9 +3,12 @@
 mkdir colors
 cp Solarized\ Light.xml colors
 cp Solarized\ Dark.xml colors
+cp Solarized\ Light.xml colors/Solarized\ Light.icls
+cp Solarized\ Dark.xml colors/Solarized\ Dark.icls
 touch IntelliJ\ IDEA\ Global\ Settings
 
 jar cfM settings.jar IntelliJ\ IDEA\ Global\ Settings colors
 
 rm -r colors
 rm IntelliJ\ IDEA\ Global\ Settings
+echo "Complete!"


### PR DESCRIPTION
I have been banging my head around hour because any changes I've made to xml files were not visible in PhpStorm. Appeared that latest Intellij-based products [use icls format](http://confluence.jetbrains.com/pages/viewpage.action?pageId=49463468) with fallback to xml if former not found.

In my case I've customized fonts and settings were copied from `Solarized Dark.xml` to `Solarized Dark.icls`. And freshly built `settings.jar` updated xml format only. And nothing changed for me

This PR adds preliminary support for icls format: simple copy from xml to icls to overwrite it. `settings.jar` provided in #50 already includes icls files. More coming up!
