### PR TITLE
added filestatus colors (standard colors)

### DIFF
--- a/Solarized Dark.icls
+++ b/Solarized Dark.icls
@@ -24,6 +24,21 @@
     <option name="SELECTION_FOREGROUND" value="2b36" />
     <option name="TEARLINE_COLOR" value="586e75" />
     <option name="WHITESPACES" value="586e75" />
+    <option name="FILESTATUS_ADDED" value="629755" />
+    <option name="FILESTATUS_DELETED" value="6c6c6c" />
+    <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c6c6c" />
+    <option name="FILESTATUS_IDEA_FILESTATUS_IGNORED" value="848504" />
+    <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
+    <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
+    <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
+    <option name="FILESTATUS_MERGED" value="9876aa" />
+    <option name="FILESTATUS_MODIFIED" value="6997bb" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="6997bb" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="6997bb" />
+    <option name="FILESTATUS_UNKNOWN" value="d1675a" />
+    <option name="FILESTATUS_addedOutside" value="629755" />
+    <option name="FILESTATUS_changelistConflict" value="d5756c" />
+    <option name="FILESTATUS_modifiedOutside" value="6897bb" />
   </colors>
   <attributes>
     <option name="ANNOTATION_NAME_ATTRIBUTES">


### PR DESCRIPTION
The solarized colors on the standard Darcula theme aren't readable for the file statuses (the name of the file on the tabs titles, project view and so on), this reverts it to the standard colors and makes everything more readable.
