### PR TITLE
Use a more generic path to the Windows settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ color themes.
     * `~/Library/Preferences/WebIDE70/colors` (PHPStorm 7.0).
 
     *Windows*
-    * `Documents and Settings/<user>/.IdeaIC13/config/colors` (IntelliJ IDEA 13 Community Edition)
+    * `%USERPROFILE%/.IdeaIC13/config/colors` (IntelliJ IDEA 13 Community Edition)
         
 2. Restart IntelliJ IDEA
 


### PR DESCRIPTION
`Documents and Settings` is deprecated in favor of the generic `Users`
path on newer Windows versions. Additionally, the new path can be used
in the command-line and scripts without problems.
