### PR TITLE
Script to generate right icls file for JDK 1.6 on Mac

### DIFF
--- a/default.sh
+++ b/default.sh
@@ -1,0 +1,17 @@
+sed -i -- 's/22029/2b36/g' *.icls   #base03
+sed -i -- 's/a2933/73642/g' *.icls  #base02
+sed -i -- 's/475b62/586e75/g' *.icls  #base01
+sed -i -- 's/536870/657b83/g' *.icls  #base00
+sed -i -- 's/708284/839496/g' *.icls  #base0
+sed -i -- 's/819090/93a1a1/g' *.icls  #base1
+sed -i -- 's/eae3cb/eee8d5/g' *.icls  #base2
+sed -i -- 's/fcf4dc/fdf6e3/g' *.icls  #base3
+sed -i -- 's/a57705/b58900/g' *.icls  #yellow
+sed -i -- 's/bd3613/cb4b16/g' *.icls  #orange
+sed -i -- 's/d11c24/dc322f/g' *.icls  #red
+sed -i -- 's/c61c6f/d33682/g' *.icls  #magenta
+sed -i -- 's/595ab7/6c71c4/g' *.icls  #violet
+sed -i -- 's/2176c7/268bd2/g' *.icls  #blue
+sed -i -- 's/259286/2aa198/g' *.icls  #cyan
+sed -i -- 's/738a04/859900/g' *.icls  #green
+

--- a/java1.6_mac.sh
+++ b/java1.6_mac.sh
@@ -1,0 +1,17 @@
+sed -i -- 's/2b36/22029/g' *.icls   #base03
+sed -i -- 's/73642/a2933/g' *.icls  #base02
+sed -i -- 's/586e75/475b62/g' *.icls  #base01
+sed -i -- 's/657b83/536870/g' *.icls  #base00
+sed -i -- 's/839496/708284/g' *.icls  #base0
+sed -i -- 's/93a1a1/819090/g' *.icls  #base1
+sed -i -- 's/eee8d5/eae3cb/g' *.icls  #base2
+sed -i -- 's/fdf6e3/fcf4dc/g' *.icls  #base3
+sed -i -- 's/b58900/a57705/g' *.icls  #yellow
+sed -i -- 's/cb4b16/bd3613/g' *.icls  #orange
+sed -i -- 's/dc322f/d11c24/g' *.icls  #red
+sed -i -- 's/d33682/c61c6f/g' *.icls  #magenta
+sed -i -- 's/6c71c4/595ab7/g' *.icls  #violet
+sed -i -- 's/268bd2/2176c7/g' *.icls  #blue
+sed -i -- 's/2aa198/259286/g' *.icls  #cyan
+sed -i -- 's/859900/738a04/g' *.icls  #green
+


### PR DESCRIPTION
Hi,
I create a simple map between sRGB and RGB for Mac java 1.6
The reason for this is because JDK1.6 for intellij is still more stable
I don't know if you use any extra color. 
In that case just let me know, I can fix it too
there are 2 script: 
java1.6_mac.sh: will modify all icls file with the right RGB value for jdk1.6
default.sh: will make the file back to the default config