### PR TITLE
Changed JavaScript brace color to red

### DIFF
--- a/Solarized Dark.icls
+++ b/Solarized Dark.icls
@@ -1504,7 +1504,7 @@
     </option>
     <option name="JS.BRACES">
       <value>
-        <option name="FOREGROUND" value="268bd2" />
+        <option name="FOREGROUND" value="dc322f" />
       </value>
     </option>
     <option name="JS.BRACKETS">


### PR DESCRIPTION
Changed JavaScript braces color to be red instead of blue, so that it's the same as in for example Java or PHP.