### PR TITLE
Removed color settings for Brackets, Braces and Parentheses

### DIFF
--- a/Solarized Dark.icls
+++ b/Solarized Dark.icls
@@ -1502,16 +1502,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="JS.BRACES">
-      <value>
-        <option name="FOREGROUND" value="268bd2" />
-      </value>
-    </option>
-    <option name="JS.BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="268bd2" />
-      </value>
-    </option>
     <option name="JS.DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="586e75" />
@@ -1659,11 +1649,6 @@
       <value>
         <option name="FOREGROUND" value="657b83" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="KOTLIN_BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="586e75" />
       </value>
     </option>
     <option name="KOTLIN_BUILTIN_ANNOTATION">
@@ -2274,11 +2259,6 @@
     <option name="Object">
       <value>
         <option name="FOREGROUND" value="b58800" />
-      </value>
-    </option>
-    <option name="PHP_BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="dc322f" />
       </value>
     </option>
     <option name="PHP_COMMENT">
@@ -3437,11 +3417,6 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="TWIG_BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="dc322f" />
-      </value>
-    </option>
     <option name="TWIG_COMMENT">
       <value>
         <option name="FOREGROUND" value="586e75" />
@@ -3802,4 +3777,3 @@
     </option>
   </attributes>
 </scheme>
-

--- a/Solarized Light.icls
+++ b/Solarized Light.icls
@@ -1473,16 +1473,6 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="JS.BRACES">
-      <value>
-        <option name="FOREGROUND" value="268bd2" />
-      </value>
-    </option>
-    <option name="JS.BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="268bd2" />
-      </value>
-    </option>
     <option name="JS.DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="586e75" />
@@ -1631,11 +1621,6 @@
       <value>
         <option name="FOREGROUND" value="657b83" />
         <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="KOTLIN_BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="586e75" />
       </value>
     </option>
     <option name="KOTLIN_BUILTIN_ANNOTATION">
@@ -2228,11 +2213,6 @@
     <option name="Object">
       <value>
         <option name="FOREGROUND" value="b58800" />
-      </value>
-    </option>
-    <option name="PHP_BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="dc322f" />
       </value>
     </option>
     <option name="PHP_COMMENT">
@@ -3390,11 +3370,6 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="TWIG_BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="dc322f" />
-      </value>
-    </option>
     <option name="TWIG_COMMENT">
       <value>
         <option name="FOREGROUND" value="93a1a1" />
@@ -3754,4 +3729,3 @@
     </option>
   </attributes>
 </scheme>
-


### PR DESCRIPTION
Removed those color settings for JS, PHP, Kotlin and Twig, so that the default text color will be used. 