### PR TITLE
Add solarized colors for Cursive's rainbow parens

### DIFF
--- a/Solarized Dark.icls
+++ b/Solarized Dark.icls
@@ -2893,6 +2893,46 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
+    <option name="Rainbow Parens Level 1 (outermost)">
+      <value>
+        <option name="FOREGROUND" value="839496" />
+      </value>
+    </option>
+    <option name="Rainbow Parens Level 2">
+      <value>
+        <option name="FOREGROUND" value="dc322f" />
+      </value>
+    </option>
+    <option name="Rainbow Parens Level 3">
+      <value>
+        <option name="FOREGROUND" value="cb4b16" />
+      </value>
+    </option>
+    <option name="Rainbow Parens Level 4">
+      <value>
+        <option name="FOREGROUND" value="b58900" />
+      </value>
+    </option>
+    <option name="Rainbow Parens Level 5">
+      <value>
+        <option name="FOREGROUND" value="859900" />
+      </value>
+    </option>
+    <option name="Rainbow Parens Level 7">
+      <value>
+        <option name="FOREGROUND" value="87ff" />
+      </value>
+    </option>
+    <option name="Rainbow Parens Level 8">
+      <value>
+        <option name="FOREGROUND" value="6c71c4" />
+      </value>
+    </option>
+    <option name="Rainbow Parens Level 9">
+      <value>
+        <option name="FOREGROUND" value="af005f" />
+      </value>
+    </option>
     <option name="Regular expression">
       <value>
         <option name="FOREGROUND" value="2aa198" />

--- a/Solarized Light.icls
+++ b/Solarized Light.icls
@@ -2846,6 +2846,46 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
+    <option name="Rainbow Parens Level 1 (outermost)">
+      <value>
+        <option name="FOREGROUND" value="839496" />
+      </value>
+    </option>
+    <option name="Rainbow Parens Level 2">
+      <value>
+        <option name="FOREGROUND" value="dc322f" />
+      </value>
+    </option>
+    <option name="Rainbow Parens Level 3">
+      <value>
+        <option name="FOREGROUND" value="cb4b16" />
+      </value>
+    </option>
+    <option name="Rainbow Parens Level 4">
+      <value>
+        <option name="FOREGROUND" value="b58900" />
+      </value>
+    </option>
+    <option name="Rainbow Parens Level 5">
+      <value>
+        <option name="FOREGROUND" value="859900" />
+      </value>
+    </option>
+    <option name="Rainbow Parens Level 7">
+      <value>
+        <option name="FOREGROUND" value="87ff" />
+      </value>
+    </option>
+    <option name="Rainbow Parens Level 8">
+      <value>
+        <option name="FOREGROUND" value="6c71c4" />
+      </value>
+    </option>
+    <option name="Rainbow Parens Level 9">
+      <value>
+        <option name="FOREGROUND" value="af005f" />
+      </value>
+    </option>
     <option name="Regular expression">
       <value>
         <option name="FOREGROUND" value="2aa198" />


### PR DESCRIPTION
Cursive is a Clojure plugin that has a rainbow parens option. This sets those parens colors to nicer Solarized ones.

<img width="210" alt="screen shot 2016-08-12 at 2 13 11 pm" src="https://cloud.githubusercontent.com/assets/59748/17635937/71d71030-6097-11e6-96bf-c42d523b070d.png">
<img width="208" alt="screen shot 2016-08-12 at 2 13 35 pm" src="https://cloud.githubusercontent.com/assets/59748/17635938/724cf962-6097-11e6-8b1e-62556476e86e.png">
