### PR TITLE
Update README for Phpstorm 2018.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Installation
 
 1. Clone this repository
 
-2. Go to `File | Import Settings...` and specify the `intellij-colors-solarized` directory or the `settings.jar` file.
+2. Go to `File | Settings... | Editor | Color Scheme`. Click the cogwheel next to the theme selelction box and specify the `intellij-colors-solarized` directory or the `settings.jar` file.
  Click `OK` in the dialog that appears.
 
 3. Restart IntelliJ IDEA


### PR DESCRIPTION
I just noticed that in Phpstorm 2018.3 has changed the way you should import settings. I've updated the README accordingly.

![afbeelding](https://user-images.githubusercontent.com/9716643/49008980-8c299780-f16f-11e8-9c47-af225437c701.png)
