### PR TITLE
Fix comments colours

### DIFF
--- a/Solarized Dark.icls
+++ b/Solarized Dark.icls
@@ -712,7 +712,7 @@
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="657b83" />
+        <option name="FOREGROUND" value="586e75" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -732,7 +732,7 @@
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="657b83" />
+        <option name="FOREGROUND" value="586e75" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -788,7 +788,7 @@
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="cb4b16" />
+        <option name="FOREGROUND" value="586e75" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>

--- a/Solarized Light.icls
+++ b/Solarized Light.icls
@@ -721,7 +721,7 @@
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="859900" />
+        <option name="FOREGROUND" value="93a1a1" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -741,7 +741,7 @@
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="859900" />
+        <option name="FOREGROUND" value="93a1a1" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -797,7 +797,7 @@
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="cb4b16" />
+        <option name="FOREGROUND" value="93a1a1" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1640,12 +1640,6 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="KOTLIN_BLOCK_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="657b83" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="KOTLIN_FUNCTION_CALL">
       <value />
     </option>
@@ -2454,7 +2448,7 @@
     </option>
     <option name="PY.SELF_PARAMETER">
       <value>
-        <option name="FOREGROUND" value="6B95B3" />
+        <option name="FOREGROUND" value="6b95b3" />
       </value>
     </option>
     <option name="PY.STRING">


### PR DESCRIPTION
Intellij Light (all are grey):
<img width="605" alt="Screenshot 2024-01-05 at 18 29 38" src="https://github.com/jkaving/intellij-colors-solarized/assets/100644/919790d9-bfff-41f3-8bdc-6eb1cf6306fb">

### Argument 1:
According to the [official documentation](https://ethanschoonover.com/solarized/) the comments should be of `base1` colour `#93a1a1`:
![image](https://github.com/jkaving/intellij-colors-solarized/assets/100644/f79aeee9-f515-4fd1-86b5-285d364bcf33)

### Argument 2:
An example for Java(Vim) from the [official documentation](https://ethanschoonover.com/solarized/):

![image](https://github.com/jkaving/intellij-colors-solarized/assets/100644/6bed7425-00eb-46f0-a188-66d1293bcf20)

Before this PR change:
* different colours
* block comment colour is too similar to main text colour and is `#657b83` which is `base00` colour
* line comment is red for some reason
<img width="571" alt="Screenshot 2024-01-05 at 18 30 03" src="https://github.com/jkaving/intellij-colors-solarized/assets/100644/1e052746-cbdd-49e5-859d-03d380395beb">

This PR changes to this:
* all comment colours have unified light grey look 
<img width="620" alt="Screenshot 2024-01-05 at 18 59 52" src="https://github.com/jkaving/intellij-colors-solarized/assets/100644/534bdefc-0aa7-43e1-b3a9-caa8aafb993e">
